### PR TITLE
Add support to show bank quantity for noted items on the tooltip

### DIFF
--- a/src/main/java/com/bankmemory/BankMemoryItemOverlay.java
+++ b/src/main/java/com/bankmemory/BankMemoryItemOverlay.java
@@ -79,6 +79,10 @@ public class BankMemoryItemOverlay extends Overlay {
                     itemCountTooltipText = "Banked: " + bankItem.getQuantity();
                     break;
                 }
+		if (bankItem.getItemId() == (item.getId() - 1)) {
+		    itemCountTooltipText = "Banked: " + bankItem.getQuantity();
+		    break;
+		}
             }
         }
 


### PR DESCRIPTION
Most item id's in the game are +1 for noted. 

For example: 
Rune chainbody ID: 1113
Rune chainbody (noted) ID: 1114

This will allow you to see Bank Quantity when you hover over a noted item in your inventory. 