### PR TITLE
feat: add Seed Vault support (multi-container: Bank + Seed Vault)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,12 +44,3 @@ tasks.withType(JavaCompile) {
     options.release.set(11)
 }
 
-// Convenience task to run RuneLite with this plugin from the test source set
-tasks.register('runRuneLite', JavaExec) {
-    group = 'application'
-    description = 'Run RuneLite with this plugin (uses RuneLiteRunner)'
-    classpath = sourceSets.test.runtimeClasspath
-    mainClass = 'com.bankmemory.RuneLiteRunner'
-    // Useful JVM args; adjust as needed
-    jvmArgs '-Xmx1024m', '-Djava.awt.headless=false'
-}

--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,16 @@ dependencies {
 group = 'com.bankmemory'
 version = '1.3.0'
 
+// Ensure we compile against Java 11 (RuneLite target) regardless of the system JDK
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(11)
+    }
+}
+
+sourceCompatibility = JavaVersion.VERSION_11
+targetCompatibility = JavaVersion.VERSION_11
+
 tasks.withType(JavaCompile) {
     options.encoding = 'UTF-8'
     options.release.set(11)

--- a/build.gradle
+++ b/build.gradle
@@ -43,3 +43,13 @@ tasks.withType(JavaCompile) {
     options.encoding = 'UTF-8'
     options.release.set(11)
 }
+
+// Convenience task to run RuneLite with this plugin from the test source set
+tasks.register('runRuneLite', JavaExec) {
+    group = 'application'
+    description = 'Run RuneLite with this plugin (uses RuneLiteRunner)'
+    classpath = sourceSets.test.runtimeClasspath
+    mainClass = 'com.bankmemory.RuneLiteRunner'
+    // Useful JVM args; adjust as needed
+    jvmArgs '-Xmx1024m', '-Djava.awt.headless=false'
+}

--- a/runelite-plugin.properties
+++ b/runelite-plugin.properties
@@ -2,5 +2,5 @@ displayName=Bank Memory
 author=LazyFaith
 support=https://github.com/Lazyfaith/runelite-bank-memory-plugin
 description=Remembers all your banks, lets you instantly search them, and lets you compare their contents.
-tags=banks, content, contents, item, items
+tags=banks, seeds, vault, content, contents, item, items
 plugins=com.bankmemory.BankMemoryPlugin

--- a/src/main/java/com/bankmemory/BankMemoryPlugin.java
+++ b/src/main/java/com/bankmemory/BankMemoryPlugin.java
@@ -15,7 +15,6 @@ import net.runelite.api.GameState;
 import net.runelite.api.InventoryID;
 import net.runelite.api.ItemContainer;
 import net.runelite.api.Player;
-import net.runelite.api.ItemContainerID;
 import net.runelite.api.events.GameStateChanged;
 import net.runelite.api.events.GameTick;
 import net.runelite.api.events.ItemContainerChanged;
@@ -150,7 +149,7 @@ public class BankMemoryPlugin extends Plugin {
             ItemContainer bank = event.getItemContainer();
             dataStore.saveAsCurrentBank(BankSave.fromCurrentBank(worldType, accountIdentifier, bank, itemManager));
         }
-        if (containerId == ItemContainerID.SEED_VAULT) {
+        if (containerId == com.bankmemory.util.Constants.SEED_VAULT_CONTAINER_ID) {
             ItemContainer vault = event.getItemContainer();
             dataStore.saveAsCurrentSeedVault(BankSave.fromCurrentBank(worldType, accountIdentifier, vault, itemManager));
         }

--- a/src/main/java/com/bankmemory/BankMemoryPlugin.java
+++ b/src/main/java/com/bankmemory/BankMemoryPlugin.java
@@ -73,6 +73,10 @@ public class BankMemoryPlugin extends Plugin {
         BankMemoryPluginPanel pluginPanel = injector.getInstance(BankMemoryPluginPanel.class);
 
         BufferedImage icon = ImageUtil.getResourceStreamFromClass(getClass(), ICON);
+        if (icon == null) {
+            // Fallback for test environments or unexpected resource resolution issues
+            icon = new BufferedImage(1, 1, BufferedImage.TYPE_INT_ARGB);
+        }
         navButton = NavigationButton.builder()
                 .tooltip(Constants.BANK_MEMORY)
                 .icon(icon)

--- a/src/main/java/com/bankmemory/BankMemoryPlugin.java
+++ b/src/main/java/com/bankmemory/BankMemoryPlugin.java
@@ -83,21 +83,23 @@ public class BankMemoryPlugin extends Plugin {
         clientToolbar.addNavigation(navButton);
 
         currentBankPanelController = injector.getInstance(CurrentBankPanelController.class);
-    BankViewPanel currentBankView = pluginPanel.getCurrentBankViewPanel();
-    clientThread.invokeLater(() -> currentBankPanelController.startUp(currentBankView));
+        BankViewPanel currentBankView = pluginPanel.getCurrentBankViewPanel();
+        clientThread.invokeLater(() -> currentBankPanelController.startUp(currentBankView));
 
-    currentSeedVaultPanelController = injector.getInstance(CurrentSeedVaultPanelController.class);
-    BankViewPanel currentSeedVaultView = pluginPanel.getCurrentSeedVaultViewPanel();
-    clientThread.invokeLater(() -> currentSeedVaultPanelController.startUp(currentSeedVaultView));
+        currentSeedVaultPanelController = injector.getInstance(CurrentSeedVaultPanelController.class);
+        BankViewPanel currentSeedVaultView = pluginPanel.getCurrentSeedVaultViewPanel();
+        clientThread.invokeLater(() -> currentSeedVaultPanelController.startUp(currentSeedVaultView));
 
         savedBanksPanelController = injector.getInstance(SavedBanksPanelController.class);
         savedBanksPanelController.startUp(pluginPanel.getSavedBanksTopPanel());
-    savedSeedVaultPanelController = injector.getInstance(SavedSeedVaultPanelController.class);
-    savedSeedVaultPanelController.startUp(pluginPanel.getSavedSeedVaultTopPanel());
-    diffPanelController = injector.getInstance(BankDiffPanelController.class);
-    diffPanelController.startUp(pluginPanel.getSavedBanksTopPanel().getDiffPanel());
-    seedVaultDiffPanelController = injector.getInstance(SeedVaultDiffPanelController.class);
-    seedVaultDiffPanelController.startUp(pluginPanel.getSavedSeedVaultTopPanel().getDiffPanel());
+        savedSeedVaultPanelController = injector.getInstance(SavedSeedVaultPanelController.class);
+        savedSeedVaultPanelController.startUp(pluginPanel.getSavedSeedVaultTopPanel());
+        
+        diffPanelController = injector.getInstance(BankDiffPanelController.class);
+        diffPanelController.startUp(pluginPanel.getSavedBanksTopPanel().getDiffPanel());
+        
+        seedVaultDiffPanelController = injector.getInstance(SeedVaultDiffPanelController.class);
+        seedVaultDiffPanelController.startUp(pluginPanel.getSavedSeedVaultTopPanel().getDiffPanel());
 
         overlayManager.add(itemOverlay);
     }
@@ -140,6 +142,7 @@ public class BankMemoryPlugin extends Plugin {
     }
 
     @Subscribe
+    @SuppressWarnings("deprecation")
     public void onItemContainerChanged(ItemContainerChanged event) {
         int containerId = event.getContainerId();
         BankWorldType worldType = BankWorldType.forWorld(client.getWorldType());
@@ -149,7 +152,7 @@ public class BankMemoryPlugin extends Plugin {
             ItemContainer bank = event.getItemContainer();
             dataStore.saveAsCurrentBank(BankSave.fromCurrentBank(worldType, accountIdentifier, bank, itemManager));
         }
-        if (containerId == com.bankmemory.util.Constants.SEED_VAULT_CONTAINER_ID) {
+        if (containerId == InventoryID.SEED_VAULT.getId()) {
             ItemContainer vault = event.getItemContainer();
             dataStore.saveAsCurrentSeedVault(BankSave.fromCurrentBank(worldType, accountIdentifier, vault, itemManager));
         }

--- a/src/main/java/com/bankmemory/BankMemoryPluginPanel.java
+++ b/src/main/java/com/bankmemory/BankMemoryPluginPanel.java
@@ -1,8 +1,11 @@
 package com.bankmemory;
 
 import com.bankmemory.bankview.BankViewPanel;
+import com.bankmemory.data.StorageType;
 import java.awt.BorderLayout;
+import java.awt.CardLayout;
 import javax.swing.BorderFactory;
+import javax.swing.JComboBox;
 import javax.swing.JPanel;
 import net.runelite.client.ui.PluginPanel;
 import net.runelite.client.ui.components.materialtabs.MaterialTab;
@@ -16,21 +19,59 @@ class BankMemoryPluginPanel extends PluginPanel {
     private final BankViewPanel currentBankViewPanel = new BankViewPanel();
     private final BankSavesTopPanel savedBanksTopPanel = new BankSavesTopPanel();
 
+    private final BankViewPanel currentSeedVaultViewPanel = new BankViewPanel();
+    private final SeedVaultSavesTopPanel savedSeedVaultTopPanel = new SeedVaultSavesTopPanel();
+
+    private final JPanel contentCards = new JPanel(new CardLayout());
+    private static final String CARD_BANK = "bank";
+    private static final String CARD_SEED = "seed";
+
     protected BankMemoryPluginPanel() {
         super(false);
         setBorder(BorderFactory.createEmptyBorder(PAD, PAD, PAD, PAD));
 
-        JPanel displayPanel = new JPanel();
-        MaterialTabGroup tabGroup = new MaterialTabGroup(displayPanel);
-        MaterialTab currentBankTab = new MaterialTab("Current bank", tabGroup, currentBankViewPanel);
-        MaterialTab savesListTab = new MaterialTab("Saved banks", tabGroup, savedBanksTopPanel);
-        tabGroup.addTab(currentBankTab);
-        tabGroup.addTab(savesListTab);
-        tabGroup.select(currentBankTab);
+        // Bank group
+        JPanel bankDisplayPanel = new JPanel();
+        MaterialTabGroup bankTabGroup = new MaterialTabGroup(bankDisplayPanel);
+        MaterialTab currentBankTab = new MaterialTab("Current", bankTabGroup, currentBankViewPanel);
+        MaterialTab savesBankTab = new MaterialTab("Saved", bankTabGroup, savedBanksTopPanel);
+        bankTabGroup.addTab(currentBankTab);
+        bankTabGroup.addTab(savesBankTab);
+        bankTabGroup.select(currentBankTab);
+        JPanel bankGroupPanel = new JPanel(new BorderLayout());
+        bankGroupPanel.add(bankTabGroup, BorderLayout.NORTH);
+        bankGroupPanel.add(bankDisplayPanel, BorderLayout.CENTER);
+
+        // Seed vault group
+        JPanel seedDisplayPanel = new JPanel();
+        MaterialTabGroup seedTabGroup = new MaterialTabGroup(seedDisplayPanel);
+        MaterialTab currentSeedTab = new MaterialTab("Current", seedTabGroup, currentSeedVaultViewPanel);
+        MaterialTab savedSeedTab = new MaterialTab("Saved", seedTabGroup, savedSeedVaultTopPanel);
+        seedTabGroup.addTab(currentSeedTab);
+        seedTabGroup.addTab(savedSeedTab);
+        seedTabGroup.select(currentSeedTab);
+        JPanel seedGroupPanel = new JPanel(new BorderLayout());
+        seedGroupPanel.add(seedTabGroup, BorderLayout.NORTH);
+        seedGroupPanel.add(seedDisplayPanel, BorderLayout.CENTER);
+
+        contentCards.add(bankGroupPanel, CARD_BANK);
+        contentCards.add(seedGroupPanel, CARD_SEED);
+
+        JComboBox<StorageType> dropdown = new JComboBox<>(StorageType.values());
+        dropdown.addActionListener(e -> {
+            StorageType selected = (StorageType) dropdown.getSelectedItem();
+            CardLayout cl = (CardLayout) contentCards.getLayout();
+            if (selected == StorageType.SEED_VAULT) {
+                cl.show(contentCards, CARD_SEED);
+            } else {
+                cl.show(contentCards, CARD_BANK);
+            }
+        });
+        dropdown.setSelectedItem(StorageType.BANK);
 
         setLayout(new BorderLayout());
-        add(tabGroup, BorderLayout.NORTH);
-        add(displayPanel, BorderLayout.CENTER);
+        add(dropdown, BorderLayout.NORTH);
+        add(contentCards, BorderLayout.CENTER);
     }
 
     BankViewPanel getCurrentBankViewPanel() {
@@ -39,5 +80,13 @@ class BankMemoryPluginPanel extends PluginPanel {
 
     BankSavesTopPanel getSavedBanksTopPanel() {
         return savedBanksTopPanel;
+    }
+
+    BankViewPanel getCurrentSeedVaultViewPanel() {
+        return currentSeedVaultViewPanel;
+    }
+
+    SeedVaultSavesTopPanel getSavedSeedVaultTopPanel() {
+        return savedSeedVaultTopPanel;
     }
 }

--- a/src/main/java/com/bankmemory/BanksListPanel.java
+++ b/src/main/java/com/bankmemory/BanksListPanel.java
@@ -56,7 +56,7 @@ public class BanksListPanel extends JPanel {
         JScrollPane scrollPane = new JScrollPane(listWrapper);
         add(scrollPane, BorderLayout.CENTER);
 
-        JButton compareBanks = new JButton("Compare bank saves");
+        JButton compareBanks = new JButton("Compare saves");
         compareBanks.addActionListener(a -> interactionListener.openBanksDiffPanel());
         add(compareBanks, BorderLayout.SOUTH);
     }

--- a/src/main/java/com/bankmemory/CurrentSeedVaultPanelController.java
+++ b/src/main/java/com/bankmemory/CurrentSeedVaultPanelController.java
@@ -1,0 +1,135 @@
+package main.java.com.bankmemory;
+
+import com.bankmemory.bankview.BankViewPanel;
+import com.bankmemory.bankview.ItemListEntry;
+import com.bankmemory.data.AbstractDataStoreUpdateListener;
+import com.bankmemory.data.AccountIdentifier;
+import com.bankmemory.data.BankItem;
+import com.bankmemory.data.BankSave;
+import com.bankmemory.data.BankWorldType;
+import com.bankmemory.data.PluginDataStore;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import javax.annotation.Nullable;
+import javax.inject.Inject;
+import javax.swing.SwingUtilities;
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.Client;
+import net.runelite.api.GameState;
+import net.runelite.api.ItemComposition;
+import net.runelite.api.events.GameStateChanged;
+import net.runelite.client.callback.ClientThread;
+import net.runelite.client.game.ItemManager;
+import net.runelite.client.util.AsyncBufferedImage;
+
+@Slf4j
+public class CurrentSeedVaultPanelController {
+    @Inject private Client client;
+    @Inject private ClientThread clientThread;
+    @Inject private ItemManager itemManager;
+    @Inject private PluginDataStore dataStore;
+
+    private BankViewPanel panel;
+
+    @Nullable private BankSave latestDisplayedData = null;
+
+    public void startUp(BankViewPanel panel) {
+        assert client.isClientThread();
+
+        this.panel = panel;
+        SwingUtilities.invokeLater(this::setPopupMenuActionOnBankView);
+
+        DataStoreListener dataStoreListener = new DataStoreListener();
+        dataStore.addListener(dataStoreListener);
+
+        if (client.getGameState() == GameState.LOGGED_IN) {
+            updateDisplayForCurrentAccount();
+        } else {
+            SwingUtilities.invokeLater(panel::displayNoDataMessage);
+        }
+    }
+
+    private void setPopupMenuActionOnBankView() {
+        this.panel.setItemListPopupMenuAction(new CopyItemsToClipboardAction(clientThread, itemManager) {
+            @Nullable
+            @Override
+            public BankSave getBankItemData() {
+                if (latestDisplayedData == null) {
+                    log.error("Tried to copy CSV data to clipboard before any current seed vault shown");
+                }
+                return latestDisplayedData;
+            }
+        });
+    }
+
+    public void onGameStateChanged(GameStateChanged gameStateChanged) {
+        assert client.isClientThread();
+
+        if (gameStateChanged.getGameState() != GameState.LOGGED_IN) {
+            return;
+        }
+        updateDisplayForCurrentAccount();
+    }
+
+    private void updateDisplayForCurrentAccount() {
+        BankWorldType worldType = BankWorldType.forWorld(client.getWorldType());
+        String accountIdentifier = AccountIdentifier.fromAccountHash(client.getAccountHash());
+        Optional<BankSave> existingSave = dataStore.getDataForCurrentSeedVault(worldType, accountIdentifier);
+        if (existingSave.isPresent()) {
+            viewSave(existingSave.get());
+        } else {
+            latestDisplayedData = null;
+            SwingUtilities.invokeLater(panel::displayNoDataMessage);
+        }
+    }
+
+    private void viewSave(BankSave save) {
+        assert client.isClientThread();
+
+        dataStore.currentSeedVaultViewed(save.getId());
+
+        boolean shouldReset = isIdentityDifferentToLastDisplayed(save);
+        boolean shouldUpdateItemsDisplay = shouldReset || isItemDataNew(save);
+        List<ItemListEntry> items = new ArrayList<>();
+        if (shouldUpdateItemsDisplay) {
+            for (BankItem i : save.getItemData()) {
+                ItemComposition ic = itemManager.getItemComposition(i.getItemId());
+                AsyncBufferedImage icon = itemManager.getImage(i.getItemId(), i.getQuantity(), i.getQuantity() > 1);
+                int geValue = itemManager.getItemPrice(i.getItemId()) * i.getQuantity();
+                int haValue = ic.getHaPrice() * i.getQuantity();
+                items.add(new ItemListEntry(ic.getName(), i.getQuantity(), icon, geValue, haValue));
+            }
+        }
+        SwingUtilities.invokeLater(() -> {
+            if (shouldReset) {
+                panel.reset();
+            }
+            panel.updateTimeDisplay(save.getDateTimeString());
+            if (shouldUpdateItemsDisplay) {
+                panel.displayItemListings(items, true);
+            }
+        });
+        latestDisplayedData = save;
+    }
+
+    private boolean isIdentityDifferentToLastDisplayed(BankSave newSave) {
+        if (latestDisplayedData == null) {
+            return true;
+        }
+        boolean accountIdentifiersSame = latestDisplayedData.getAccountIdentifier().equalsIgnoreCase(newSave.getAccountIdentifier());
+        boolean worldTypesSame = latestDisplayedData.getWorldType() == newSave.getWorldType();
+        return !accountIdentifiersSame || !worldTypesSame;
+    }
+
+    private boolean isItemDataNew(BankSave newSave) {
+        return latestDisplayedData == null || !latestDisplayedData.getItemData().equals(newSave.getItemData());
+    }
+
+    private class DataStoreListener extends AbstractDataStoreUpdateListener {
+        @Override
+        public void currentSeedVaultsListChanged() {
+            updateDisplayForCurrentAccount();
+        }
+    }
+}

--- a/src/main/java/com/bankmemory/CurrentSeedVaultPanelController.java
+++ b/src/main/java/com/bankmemory/CurrentSeedVaultPanelController.java
@@ -47,7 +47,11 @@ public class CurrentSeedVaultPanelController {
         if (client.getGameState() == GameState.LOGGED_IN) {
             updateDisplayForCurrentAccount();
         } else {
-            SwingUtilities.invokeLater(panel::displayNoDataMessage);
+            SwingUtilities.invokeLater(() -> {
+                panel.setNoDataMessage("Seed Vault Memory",
+                        "Log in to a character and open a seed vault to populate vault data for that character.");
+                panel.displayNoDataMessage();
+            });
         }
     }
 
@@ -81,7 +85,11 @@ public class CurrentSeedVaultPanelController {
             viewSave(existingSave.get());
         } else {
             latestDisplayedData = null;
-            SwingUtilities.invokeLater(panel::displayNoDataMessage);
+            SwingUtilities.invokeLater(() -> {
+                panel.setNoDataMessage("Seed Vault Memory",
+                        "Open a seed vault to populate vault data for this character.");
+                panel.displayNoDataMessage();
+            });
         }
     }
 

--- a/src/main/java/com/bankmemory/CurrentSeedVaultPanelController.java
+++ b/src/main/java/com/bankmemory/CurrentSeedVaultPanelController.java
@@ -9,6 +9,7 @@ import com.bankmemory.data.BankSave;
 import com.bankmemory.data.BankWorldType;
 import com.bankmemory.data.PluginDataStore;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 import javax.annotation.Nullable;
@@ -100,6 +101,8 @@ public class CurrentSeedVaultPanelController {
                 int haValue = ic.getHaPrice() * i.getQuantity();
                 items.add(new ItemListEntry(ic.getName(), i.getQuantity(), icon, geValue, haValue));
             }
+            // Sort: seeds first (alphabetical), saplings last (alphabetical)
+            items.sort(seedVaultComparator());
         }
         SwingUtilities.invokeLater(() -> {
             if (shouldReset) {
@@ -124,6 +127,16 @@ public class CurrentSeedVaultPanelController {
 
     private boolean isItemDataNew(BankSave newSave) {
         return latestDisplayedData == null || !latestDisplayedData.getItemData().equals(newSave.getItemData());
+    }
+
+    private static Comparator<ItemListEntry> seedVaultComparator() {
+        return Comparator
+                .comparing((ItemListEntry e) -> isSapling(e.getName()) ? 1 : 0)
+                .thenComparing(e -> e.getName().toLowerCase());
+    }
+
+    private static boolean isSapling(String name) {
+        return name != null && name.toLowerCase().contains("sapling");
     }
 
     private class DataStoreListener extends AbstractDataStoreUpdateListener {

--- a/src/main/java/com/bankmemory/CurrentSeedVaultPanelController.java
+++ b/src/main/java/com/bankmemory/CurrentSeedVaultPanelController.java
@@ -1,4 +1,4 @@
-package main.java.com.bankmemory;
+package com.bankmemory;
 
 import com.bankmemory.bankview.BankViewPanel;
 import com.bankmemory.bankview.ItemListEntry;

--- a/src/main/java/com/bankmemory/CurrentSeedVaultPanelController.java
+++ b/src/main/java/com/bankmemory/CurrentSeedVaultPanelController.java
@@ -131,8 +131,8 @@ public class CurrentSeedVaultPanelController {
 
     private static Comparator<ItemListEntry> seedVaultComparator() {
         return Comparator
-                .comparing((ItemListEntry e) -> isSapling(e.getName()) ? 1 : 0)
-                .thenComparing(e -> e.getName().toLowerCase());
+                .comparing((ItemListEntry e) -> isSapling(e.getItemName()) ? 1 : 0)
+                .thenComparing(e -> e.getItemName().toLowerCase());
     }
 
     private static boolean isSapling(String name) {

--- a/src/main/java/com/bankmemory/SavedSeedVaultPanelController.java
+++ b/src/main/java/com/bankmemory/SavedSeedVaultPanelController.java
@@ -8,6 +8,7 @@ import com.bankmemory.data.DisplayNameMapper;
 import com.bankmemory.data.PluginDataStore;
 import com.bankmemory.util.ClipboardActions;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -110,6 +111,7 @@ public class SavedSeedVaultPanelController {
             int haValue = ic.getHaPrice() * i.getQuantity();
             items.add(new ItemListEntry(ic.getName(), i.getQuantity(), icon, geValue, haValue));
         }
+        items.sort(seedVaultComparator());
         SwingUtilities.invokeLater(() -> {
             workingToOpen.set(false);
             saveForClipboardAction = foundSave;
@@ -182,5 +184,15 @@ public class SavedSeedVaultPanelController {
         public void displayNameMapUpdated() {
             updateCurrentVaultsList();
         }
+    }
+
+    private static Comparator<ItemListEntry> seedVaultComparator() {
+        return Comparator
+                .comparing((ItemListEntry e) -> isSapling(e.getName()) ? 1 : 0)
+                .thenComparing(e -> e.getName().toLowerCase());
+    }
+
+    private static boolean isSapling(String name) {
+        return name != null && name.toLowerCase().contains("sapling");
     }
 }

--- a/src/main/java/com/bankmemory/SavedSeedVaultPanelController.java
+++ b/src/main/java/com/bankmemory/SavedSeedVaultPanelController.java
@@ -1,0 +1,186 @@
+package main.java.com.bankmemory;
+
+import com.bankmemory.bankview.ItemListEntry;
+import com.bankmemory.data.BankItem;
+import com.bankmemory.data.BankSave;
+import com.bankmemory.data.DataStoreUpdateListener;
+import com.bankmemory.data.DisplayNameMapper;
+import com.bankmemory.data.PluginDataStore;
+import com.bankmemory.util.ClipboardActions;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
+import javax.annotation.Nullable;
+import javax.inject.Inject;
+import javax.swing.ImageIcon;
+import javax.swing.SwingUtilities;
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.Client;
+import net.runelite.api.ItemComposition;
+import net.runelite.client.callback.ClientThread;
+import net.runelite.client.game.ItemManager;
+import net.runelite.client.util.AsyncBufferedImage;
+
+@Slf4j
+public class SavedSeedVaultPanelController {
+
+    @Inject private Client client;
+    @Inject private ClientThread clientThread;
+    @Inject private ItemManager itemManager;
+    @Inject private PluginDataStore dataStore;
+
+    private SeedVaultSavesTopPanel topPanel;
+    private ImageIcon casketIcon;
+    private ImageIcon notedCasketIcon;
+    private final AtomicBoolean workingToOpen = new AtomicBoolean();
+    private DataStoreListener dataStoreListener;
+    @Nullable BankSave saveForClipboardAction;
+
+    public void startUp(SeedVaultSavesTopPanel topPanel) {
+        assert SwingUtilities.isEventDispatchThread();
+
+        this.topPanel = topPanel;
+        topPanel.setVaultsListInteractionListener(new SeedVaultsListInteractionListenerImpl());
+        casketIcon = new ImageIcon(itemManager.getImage(405));
+        notedCasketIcon = new ImageIcon(itemManager.getImage(406));
+
+        topPanel.displayVaultsListPanel();
+        updateCurrentVaultsList();
+
+        setPopupMenuActionOnView();
+
+        dataStoreListener = new DataStoreListener();
+        dataStore.addListener(dataStoreListener);
+    }
+
+    private void updateCurrentVaultsList() {
+        List<BanksListEntry> saves = new ArrayList<>();
+        DisplayNameMapper nameMapper = dataStore.getDisplayNameMapper();
+
+        for (BankSave save : dataStore.getCurrentSeedVaultsList()) {
+            String displayName = nameMapper.map(save.getAccountIdentifier());
+            saves.add(new BanksListEntry(
+                    save.getId(), casketIcon, save.getWorldType(), "Current seed vault", displayName, save.getDateTimeString()));
+        }
+        for (BankSave save : dataStore.getSnapshotSeedVaultsList()) {
+            String displayName = nameMapper.map(save.getAccountIdentifier());
+            saves.add(new BanksListEntry(
+                    save.getId(), notedCasketIcon, save.getWorldType(), save.getSaveName(), displayName, save.getDateTimeString()));
+        }
+
+        Runnable updateList = () -> topPanel.updateVaultsList(saves);
+        if (SwingUtilities.isEventDispatchThread()) {
+            updateList.run();
+        } else {
+            SwingUtilities.invokeLater(updateList);
+        }
+    }
+
+    private void setPopupMenuActionOnView() {
+        topPanel.getVaultViewPanel().setItemListPopupMenuAction(new CopyItemsToClipboardAction(clientThread, itemManager) {
+            @Nullable
+            @Override
+            public BankSave getBankItemData() {
+                if (saveForClipboardAction == null) {
+                    log.error("Tried to copy CSV data to clipboard before any seed vault save has been opened");
+                }
+                return saveForClipboardAction;
+            }
+        });
+    }
+
+    private void openSaved(BanksListEntry selected) {
+        assert client.isClientThread();
+
+        Optional<BankSave> save = dataStore.getBankSaveWithId(selected.getSaveId());
+        if (!save.isPresent()) {
+            log.error("Selected missing seed vault save: {}", selected);
+            workingToOpen.set(false);
+            return;
+        }
+        BankSave foundSave = save.get();
+
+        List<ItemListEntry> items = new ArrayList<>();
+
+        for (BankItem i : foundSave.getItemData()) {
+            ItemComposition ic = itemManager.getItemComposition(i.getItemId());
+            AsyncBufferedImage icon = itemManager.getImage(i.getItemId(), i.getQuantity(), i.getQuantity() > 1);
+            int geValue = itemManager.getItemPrice(i.getItemId()) * i.getQuantity();
+            int haValue = ic.getHaPrice() * i.getQuantity();
+            items.add(new ItemListEntry(ic.getName(), i.getQuantity(), icon, geValue, haValue));
+        }
+        SwingUtilities.invokeLater(() -> {
+            workingToOpen.set(false);
+            saveForClipboardAction = foundSave;
+            topPanel.displaySavedVaultData(selected.getSaveName(), items, foundSave.getDateTimeString());
+        });
+    }
+
+    public void shutDown() {
+        dataStore.removeListener(dataStoreListener);
+    }
+
+    private class SeedVaultsListInteractionListenerImpl implements SeedVaultsListInteractionListener {
+        @Override
+        public void selectedToOpen(BanksListEntry save) {
+            if (workingToOpen.get()) {
+                return;
+            }
+            workingToOpen.set(true);
+            clientThread.invokeLater(() -> openSaved(save));
+        }
+
+        @Override
+        public void selectedToDelete(BanksListEntry save) {
+            dataStore.deleteBankSaveWithId(save.getSaveId());
+        }
+
+        @Override
+        public void saveSeedVaultAs(BanksListEntry save, String saveName) {
+            Optional<BankSave> existingSave = dataStore.getBankSaveWithId(save.getSaveId());
+            if (existingSave.isPresent()) {
+                dataStore.saveAsSnapshotSeedVault(saveName, existingSave.get());
+            } else {
+                log.error("Tried to 'Save As' missing seed vault save: {}", save);
+            }
+        }
+
+        @Override
+        public void copySeedVaultSaveItemDataToClipboard(BanksListEntry save) {
+            Optional<BankSave> existingSave = dataStore.getBankSaveWithId(save.getSaveId());
+            if (existingSave.isPresent()) {
+                ClipboardActions.copyItemDataAsTsvToClipboardOnClientThread(clientThread, itemManager, existingSave.get().getItemData());
+            } else {
+                log.error("Tried to copy CSV data to clipboard for missing seed vault save: {}", save);
+            }
+        }
+
+        @Override
+        public void openSeedVaultsDiffPanel() {
+            topPanel.showVaultDiffPanel();
+        }
+    }
+
+    private class DataStoreListener implements DataStoreUpdateListener {
+        @Override
+        public void currentSeedVaultsListChanged() {
+            updateCurrentVaultsList();
+        }
+
+        @Override
+        public void currentSeedVaultsListOrderChanged() {
+            updateCurrentVaultsList();
+        }
+
+        @Override
+        public void snapshotSeedVaultsListChanged() {
+            updateCurrentVaultsList();
+        }
+
+        @Override
+        public void displayNameMapUpdated() {
+            updateCurrentVaultsList();
+        }
+    }
+}

--- a/src/main/java/com/bankmemory/SavedSeedVaultPanelController.java
+++ b/src/main/java/com/bankmemory/SavedSeedVaultPanelController.java
@@ -1,4 +1,4 @@
-package main.java.com.bankmemory;
+package com.bankmemory;
 
 import com.bankmemory.bankview.ItemListEntry;
 import com.bankmemory.data.BankItem;

--- a/src/main/java/com/bankmemory/SavedSeedVaultPanelController.java
+++ b/src/main/java/com/bankmemory/SavedSeedVaultPanelController.java
@@ -3,7 +3,7 @@ package com.bankmemory;
 import com.bankmemory.bankview.ItemListEntry;
 import com.bankmemory.data.BankItem;
 import com.bankmemory.data.BankSave;
-import com.bankmemory.data.DataStoreUpdateListener;
+import com.bankmemory.data.AbstractDataStoreUpdateListener;
 import com.bankmemory.data.DisplayNameMapper;
 import com.bankmemory.data.PluginDataStore;
 import com.bankmemory.util.ClipboardActions;
@@ -164,7 +164,7 @@ public class SavedSeedVaultPanelController {
         }
     }
 
-    private class DataStoreListener implements DataStoreUpdateListener {
+    private class DataStoreListener extends AbstractDataStoreUpdateListener {
         @Override
         public void currentSeedVaultsListChanged() {
             updateCurrentVaultsList();

--- a/src/main/java/com/bankmemory/SavedSeedVaultPanelController.java
+++ b/src/main/java/com/bankmemory/SavedSeedVaultPanelController.java
@@ -188,8 +188,8 @@ public class SavedSeedVaultPanelController {
 
     private static Comparator<ItemListEntry> seedVaultComparator() {
         return Comparator
-                .comparing((ItemListEntry e) -> isSapling(e.getName()) ? 1 : 0)
-                .thenComparing(e -> e.getName().toLowerCase());
+                .comparing((ItemListEntry e) -> isSapling(e.getItemName()) ? 1 : 0)
+                .thenComparing(e -> e.getItemName().toLowerCase());
     }
 
     private static boolean isSapling(String name) {

--- a/src/main/java/com/bankmemory/SeedVaultDiffPanelController.java
+++ b/src/main/java/com/bankmemory/SeedVaultDiffPanelController.java
@@ -115,6 +115,7 @@ public class SeedVaultDiffPanelController {
             items.add(new ItemListEntry(ic.getName(), i.getQuantity(), icon, geValue, haValue));
         }
 
+        items.sort(seedVaultComparator());
         SwingUtilities.invokeLater(() -> diffPanel.displayItems(items, keepListPosition));
     }
 
@@ -122,6 +123,16 @@ public class SeedVaultDiffPanelController {
         dataStore.removeListener(dataListener);
         lastBeforeSelection = null;
         lastAfterSelection = null;
+    }
+
+    private static java.util.Comparator<ItemListEntry> seedVaultComparator() {
+        return java.util.Comparator
+                .comparing((ItemListEntry e) -> isSapling(e.getName()) ? 1 : 0)
+                .thenComparing(e -> e.getName().toLowerCase());
+    }
+
+    private static boolean isSapling(String name) {
+        return name != null && name.toLowerCase().contains("sapling");
     }
 
     private class DataUpdateListener extends AbstractDataStoreUpdateListener {

--- a/src/main/java/com/bankmemory/SeedVaultDiffPanelController.java
+++ b/src/main/java/com/bankmemory/SeedVaultDiffPanelController.java
@@ -1,4 +1,4 @@
-package main.java.com.bankmemory;
+package com.bankmemory;
 
 import com.bankmemory.BankDiffListOption.Type;
 import com.bankmemory.bankview.ItemListEntry;

--- a/src/main/java/com/bankmemory/SeedVaultDiffPanelController.java
+++ b/src/main/java/com/bankmemory/SeedVaultDiffPanelController.java
@@ -127,8 +127,8 @@ public class SeedVaultDiffPanelController {
 
     private static java.util.Comparator<ItemListEntry> seedVaultComparator() {
         return java.util.Comparator
-                .comparing((ItemListEntry e) -> isSapling(e.getName()) ? 1 : 0)
-                .thenComparing(e -> e.getName().toLowerCase());
+                .comparing((ItemListEntry e) -> isSapling(e.getItemName()) ? 1 : 0)
+                .thenComparing(e -> e.getItemName().toLowerCase());
     }
 
     private static boolean isSapling(String name) {

--- a/src/main/java/com/bankmemory/SeedVaultDiffPanelController.java
+++ b/src/main/java/com/bankmemory/SeedVaultDiffPanelController.java
@@ -1,0 +1,143 @@
+package main.java.com.bankmemory;
+
+import com.bankmemory.BankDiffListOption.Type;
+import com.bankmemory.bankview.ItemListEntry;
+import com.bankmemory.data.AbstractDataStoreUpdateListener;
+import com.bankmemory.data.BankItem;
+import com.bankmemory.data.BankSave;
+import com.bankmemory.data.DataStoreUpdateListener;
+import com.bankmemory.data.DisplayNameMapper;
+import com.bankmemory.data.PluginDataStore;
+import java.util.ArrayList;
+import java.util.List;
+import javax.inject.Inject;
+import javax.swing.SwingUtilities;
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.Client;
+import net.runelite.api.ItemComposition;
+import net.runelite.client.callback.ClientThread;
+import net.runelite.client.game.ItemManager;
+import net.runelite.client.util.AsyncBufferedImage;
+
+@Slf4j
+public class SeedVaultDiffPanelController {
+
+    @Inject private Client client;
+    @Inject private ClientThread clientThread;
+    @Inject private ItemManager itemManager;
+    @Inject private PluginDataStore dataStore;
+    @Inject private ItemListDiffGenerator diffGenerator;
+
+    private BankDiffPanel diffPanel;
+    private DataUpdateListener dataListener;
+    private BankDiffListOption lastBeforeSelection;
+    private BankDiffListOption lastAfterSelection;
+
+    public void startUp(BankDiffPanel diffPanel) {
+        this.diffPanel = diffPanel;
+        dataListener = new DataUpdateListener();
+        diffPanel.setInteractionListener(this::userSelectedSaves);
+        diffPanel.addHierarchyListener(e -> diffPanel.resetSelectionsAndItemList());
+        dataStore.addListener(dataListener);
+        updateForLatestData(true);
+    }
+
+    private void updateForLatestData(boolean currentChanged) {
+        assert SwingUtilities.isEventDispatchThread();
+
+        List<BankDiffListOption> current = new ArrayList<>();
+        List<BankDiffListOption> snapshots = new ArrayList<>();
+        DisplayNameMapper nameMapper = dataStore.getDisplayNameMapper();
+
+        for (BankSave save : dataStore.getCurrentSeedVaultsList()) {
+            String displayName = nameMapper.map(save.getAccountIdentifier());
+            current.add(new BankDiffListOption(displayName, Type.CURRENT, save));
+        }
+        for (BankSave save : dataStore.getSnapshotSeedVaultsList()) {
+            snapshots.add(new BankDiffListOption(save.getSaveName(), Type.SNAPSHOT, save));
+        }
+
+        diffPanel.displayBankOptions(current, snapshots);
+
+        BankDiffListOption equivalentBefore = findEquivalent(lastBeforeSelection, current, snapshots);
+        BankDiffListOption equivalentAfter = findEquivalent(lastAfterSelection, current, snapshots);
+        if (equivalentBefore != null && equivalentAfter != null) {
+            diffPanel.setSelections(equivalentBefore, equivalentAfter);
+            if (currentChanged && (equivalentBefore.getBankType() == Type.CURRENT || equivalentAfter.getBankType() == Type.CURRENT)) {
+                displayDiffOfSaves(equivalentBefore, equivalentAfter, true);
+            }
+        }
+    }
+
+    private BankDiffListOption findEquivalent(
+            BankDiffListOption old,
+            List<BankDiffListOption> current,
+            List<BankDiffListOption> snapshots) {
+        if (old == null) {
+            return null;
+        }
+        switch (old.getBankType()) {
+            case CURRENT:
+                return current.stream()
+                        .filter(b -> old.getSave().getAccountIdentifier().equalsIgnoreCase(b.getSave().getAccountIdentifier()))
+                        .findAny().orElse(null);
+            case SNAPSHOT:
+                return snapshots.stream()
+                        .filter(b -> old.getSave().getId() == b.getSave().getId())
+                        .findAny().orElse(null);
+        }
+        throw new AssertionError();
+    }
+
+    private void userSelectedSaves(BankDiffListOption before, BankDiffListOption after) {
+        assert SwingUtilities.isEventDispatchThread();
+        lastBeforeSelection = before;
+        lastAfterSelection = after;
+        displayDiffOfSaves(before, after, false);
+    }
+
+    private void displayDiffOfSaves(BankDiffListOption before, BankDiffListOption after, boolean keepListPosition) {
+        assert SwingUtilities.isEventDispatchThread();
+
+        List<BankItem> differences = diffGenerator.findDifferencesBetween(
+                before.getSave().getItemData(), after.getSave().getItemData());
+        clientThread.invokeLater(() -> gatherItemDataToDisplay(differences, keepListPosition));
+    }
+
+    private void gatherItemDataToDisplay(List<BankItem> differences, boolean keepListPosition) {
+        List<ItemListEntry> items = new ArrayList<>();
+
+        for (BankItem i : differences) {
+            ItemComposition ic = itemManager.getItemComposition(i.getItemId());
+            AsyncBufferedImage icon = itemManager.getImage(i.getItemId(), i.getQuantity(), false);
+            int geValue = itemManager.getItemPrice(i.getItemId()) * i.getQuantity();
+            int haValue = ic.getHaPrice() * i.getQuantity();
+            items.add(new ItemListEntry(ic.getName(), i.getQuantity(), icon, geValue, haValue));
+        }
+
+        SwingUtilities.invokeLater(() -> diffPanel.displayItems(items, keepListPosition));
+    }
+
+    public void shutDown() {
+        dataStore.removeListener(dataListener);
+        lastBeforeSelection = null;
+        lastAfterSelection = null;
+    }
+
+    private class DataUpdateListener extends AbstractDataStoreUpdateListener {
+        @Override
+        public void currentSeedVaultsListChanged() {
+            SwingUtilities.invokeLater(() -> updateForLatestData(true));
+        }
+
+        @Override
+        public void snapshotSeedVaultsListChanged() {
+            SwingUtilities.invokeLater(() -> updateForLatestData(false));
+        }
+
+        @Override
+        public void displayNameMapUpdated() {
+            SwingUtilities.invokeLater(() -> updateForLatestData(false));
+        }
+    }
+}

--- a/src/main/java/com/bankmemory/SeedVaultSavesTopPanel.java
+++ b/src/main/java/com/bankmemory/SeedVaultSavesTopPanel.java
@@ -1,4 +1,4 @@
-package main.java.com.bankmemory;
+package com.bankmemory;
 
 import com.bankmemory.bankview.BankViewPanel;
 import com.bankmemory.bankview.ItemListEntry;

--- a/src/main/java/com/bankmemory/SeedVaultSavesTopPanel.java
+++ b/src/main/java/com/bankmemory/SeedVaultSavesTopPanel.java
@@ -1,0 +1,89 @@
+package main.java.com.bankmemory;
+
+import com.bankmemory.bankview.BankViewPanel;
+import com.bankmemory.bankview.ItemListEntry;
+import java.awt.BorderLayout;
+import java.awt.image.BufferedImage;
+import java.util.List;
+import javax.swing.BoxLayout;
+import javax.swing.Icon;
+import javax.swing.ImageIcon;
+import javax.swing.JButton;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import net.runelite.client.util.ImageUtil;
+import net.runelite.client.util.SwingUtil;
+
+public class SeedVaultSavesTopPanel extends JPanel {
+    static {
+        BufferedImage backIcon = ImageUtil.getResourceStreamFromClass(SeedVaultSavesTopPanel.class, "back_icon.png");
+        BACK_ICON = new ImageIcon(backIcon);
+        BACK_ICON_HOVER = new ImageIcon(ImageUtil.alphaOffset(backIcon, -100));
+    }
+
+    private static final Icon BACK_ICON;
+    private static final Icon BACK_ICON_HOVER;
+
+    private final SeedVaultsListPanel vaultsListPanel = new SeedVaultsListPanel();
+    private final BankViewPanel vaultViewPanel = new BankViewPanel();
+    private final BankDiffPanel vaultDiffPanel = new BankDiffPanel();
+    private final JPanel backButtonAndTitle = new JPanel();
+    private final JLabel subUiTitle = new JLabel();
+
+    public SeedVaultSavesTopPanel() {
+        super();
+        setLayout(new BorderLayout());
+
+        backButtonAndTitle.setLayout(new BoxLayout(backButtonAndTitle, BoxLayout.LINE_AXIS));
+        JButton backButton = new JButton(BACK_ICON);
+        SwingUtil.removeButtonDecorations(backButton);
+        backButton.setRolloverIcon(BACK_ICON_HOVER);
+        backButton.addActionListener(e -> displayVaultsListPanel());
+        backButtonAndTitle.add(backButton);
+        backButtonAndTitle.add(subUiTitle);
+    }
+
+    void setVaultsListInteractionListener(SeedVaultsListInteractionListener listener) {
+        vaultsListPanel.setInteractionListener(listener);
+    }
+
+    void displayVaultsListPanel() {
+        vaultViewPanel.reset();
+        removeAll();
+        add(vaultsListPanel, BorderLayout.CENTER);
+        revalidate();
+        repaint();
+    }
+
+    void updateVaultsList(List<BanksListEntry> entries) {
+        vaultsListPanel.updateVaultsList(entries);
+    }
+
+    void displaySavedVaultData(String saveName, List<ItemListEntry> items, String timeString) {
+        removeAll();
+        subUiTitle.setText(saveName);
+        add(backButtonAndTitle, BorderLayout.NORTH);
+        add(vaultViewPanel, BorderLayout.CENTER);
+        vaultViewPanel.updateTimeDisplay(timeString);
+        vaultViewPanel.displayItemListings(items, false);
+        revalidate();
+        repaint();
+    }
+
+    public BankViewPanel getVaultViewPanel() {
+        return vaultViewPanel;
+    }
+
+    public BankDiffPanel getDiffPanel() {
+        return vaultDiffPanel;
+    }
+
+    void showVaultDiffPanel() {
+        removeAll();
+        subUiTitle.setText("Seed vault comparison");
+        add(backButtonAndTitle, BorderLayout.NORTH);
+        add(vaultDiffPanel, BorderLayout.CENTER);
+        revalidate();
+        repaint();
+    }
+}

--- a/src/main/java/com/bankmemory/SeedVaultsListInteractionListener.java
+++ b/src/main/java/com/bankmemory/SeedVaultsListInteractionListener.java
@@ -1,0 +1,13 @@
+package main.java.com.bankmemory;
+
+public interface SeedVaultsListInteractionListener {
+    void selectedToOpen(BanksListEntry save);
+
+    void selectedToDelete(BanksListEntry save);
+
+    void saveSeedVaultAs(BanksListEntry save, String saveName);
+
+    void copySeedVaultSaveItemDataToClipboard(BanksListEntry save);
+
+    void openSeedVaultsDiffPanel();
+}

--- a/src/main/java/com/bankmemory/SeedVaultsListInteractionListener.java
+++ b/src/main/java/com/bankmemory/SeedVaultsListInteractionListener.java
@@ -1,4 +1,4 @@
-package main.java.com.bankmemory;
+package com.bankmemory;
 
 public interface SeedVaultsListInteractionListener {
     void selectedToOpen(BanksListEntry save);

--- a/src/main/java/com/bankmemory/SeedVaultsListPanel.java
+++ b/src/main/java/com/bankmemory/SeedVaultsListPanel.java
@@ -1,0 +1,212 @@
+package main.java.com.bankmemory;
+
+import com.bankmemory.data.BankWorldType;
+import com.bankmemory.util.Constants;
+import java.awt.BorderLayout;
+import java.awt.Color;
+import java.awt.Cursor;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.MouseInfo;
+import java.awt.event.ActionEvent;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import java.util.List;
+import javax.swing.AbstractAction;
+import javax.swing.Action;
+import javax.swing.BorderFactory;
+import javax.swing.JButton;
+import javax.swing.JLabel;
+import javax.swing.JOptionPane;
+import javax.swing.JPanel;
+import javax.swing.JPopupMenu;
+import javax.swing.JScrollPane;
+import javax.swing.SwingUtilities;
+import net.runelite.client.ui.ColorScheme;
+import net.runelite.client.ui.FontManager;
+import net.runelite.client.ui.components.PluginErrorPanel;
+
+public class SeedVaultsListPanel extends JPanel {
+
+    private static final String DELETE_SAVE = "Delete save...";
+    private static final String SAVE_SNAPSHOT = "Save snapshot...";
+
+    private final PluginErrorPanel noDataMessage;
+    private final JPanel listPanel;
+    private final JPopupMenu entryContextMenu;
+    private final ListEntryMouseListener mouseListener;
+    private SeedVaultsListInteractionListener interactionListener;
+
+    public SeedVaultsListPanel() {
+        super();
+        mouseListener = new ListEntryMouseListener();
+        entryContextMenu = createContextMenu();
+
+        setLayout(new BorderLayout());
+        setBorder(BorderFactory.createEmptyBorder(Constants.PAD, 0, Constants.PAD, 0));
+
+        noDataMessage = new PluginErrorPanel();
+        noDataMessage.setContent("No seed vault saves", "You currently do not have any seed vault saves.");
+        add(noDataMessage, BorderLayout.NORTH);
+
+        listPanel = new JPanel(new GridBagLayout());
+        JPanel listWrapper = new JPanel(new BorderLayout());
+        listWrapper.add(listPanel, BorderLayout.NORTH);
+        JScrollPane scrollPane = new JScrollPane(listWrapper);
+        add(scrollPane, BorderLayout.CENTER);
+
+        JButton compareSaves = new JButton("Compare seed vault saves");
+        compareSaves.addActionListener(a -> interactionListener.openSeedVaultsDiffPanel());
+        add(compareSaves, BorderLayout.SOUTH);
+    }
+
+    private JPopupMenu createContextMenu() {
+        JPopupMenu menu = new JPopupMenu();
+        menu.add(createMenuSaveAsAction(menu));
+        menu.add(createMenuCopyItemDataToClipboardAction(menu));
+        menu.add(createMenuDeleteAction(menu));
+        return menu;
+    }
+
+    private Action createMenuSaveAsAction(JPopupMenu menu) {
+        return new AbstractAction(SAVE_SNAPSHOT) {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                String inputName;
+                do {
+                    inputName = JOptionPane.showInputDialog(
+                            SeedVaultsListPanel.this, "Enter name for new seed vault snapshot:", "Save Snapshot As", JOptionPane.PLAIN_MESSAGE);
+                    if (inputName == null) {
+                        return;
+                    }
+                    inputName = inputName.trim();
+                } while (inputName.isEmpty());
+
+                BanksListEntry save = ((EntryPanel) menu.getInvoker()).entry;
+                interactionListener.saveSeedVaultAs(save, inputName);
+            }
+        };
+    }
+
+    private Action createMenuCopyItemDataToClipboardAction(JPopupMenu menu) {
+        return new AbstractAction(Constants.ACTION_COPY_ITEM_DATA_TO_CLIPBOARD) {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                BanksListEntry save = ((EntryPanel) menu.getInvoker()).entry;
+                interactionListener.copySeedVaultSaveItemDataToClipboard(save);
+            }
+        };
+    }
+
+    private Action createMenuDeleteAction(JPopupMenu menu) {
+        return new AbstractAction(DELETE_SAVE) {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                String message = "Are you sure you want to delete this save?";
+                int result = JOptionPane.showConfirmDialog(
+                        SeedVaultsListPanel.this, message, Constants.BANK_MEMORY, JOptionPane.YES_NO_OPTION);
+                if (result == JOptionPane.YES_OPTION) {
+                    BanksListEntry save = ((EntryPanel) menu.getInvoker()).entry;
+                    interactionListener.selectedToDelete(save);
+                }
+            }
+        };
+    }
+
+    public void setInteractionListener(SeedVaultsListInteractionListener listener) {
+        interactionListener = listener;
+    }
+
+    public void updateVaultsList(List<BanksListEntry> entries) {
+        listPanel.removeAll();
+
+        noDataMessage.setVisible(entries.isEmpty());
+        if (!entries.isEmpty()) {
+            displayList(entries);
+        }
+
+        revalidate();
+        repaint();
+    }
+
+    private void displayList(List<BanksListEntry> entries) {
+        GridBagConstraints c = new GridBagConstraints();
+        c.fill = GridBagConstraints.HORIZONTAL;
+        c.weightx = 1;
+        c.gridx = 0;
+        c.gridy = 0;
+        for (BanksListEntry entry : entries) {
+            JPanel entriesGapPad = new JPanel(new BorderLayout());
+            entriesGapPad.setBorder(BorderFactory.createEmptyBorder(Constants.PAD / 2, 0, Constants.PAD / 2, 0));
+            entriesGapPad.add(new EntryPanel(entry), BorderLayout.NORTH);
+            listPanel.add(entriesGapPad, c);
+            c.gridy++;
+        }
+    }
+
+    private class EntryPanel extends JPanel {
+        final BanksListEntry entry;
+
+        public EntryPanel(BanksListEntry entry) {
+            this.entry = entry;
+
+            setLayout(new GridBagLayout());
+            setBorder(BorderFactory.createEmptyBorder(Constants.PAD, Constants.PAD, Constants.PAD, Constants.PAD));
+            setBackground(ColorScheme.DARKER_GRAY_COLOR);
+            setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
+            setToolTipText(entry.getDateTime());
+            setComponentPopupMenu(entryContextMenu);
+
+            GridBagConstraints c = new GridBagConstraints();
+            c.gridx = 0;
+            c.gridy = 0;
+            c.weightx = 0;
+            c.gridheight = 2;
+            add(new JLabel(entry.getIcon()), c);
+
+            c.fill = GridBagConstraints.HORIZONTAL;
+            c.gridx = 1;
+            c.weightx = 1;
+            c.gridheight = 1;
+            add(new JLabel(entry.getSaveName()), c);
+
+            c.gridy = 1;
+            String subText = entry.getAccountDisplayName();
+            if (entry.getWorldType() != BankWorldType.DEFAULT) {
+                subText += " (" + entry.getWorldType().getDisplayString() + ")";
+            }
+            JLabel subLabel = new JLabel(subText);
+            subLabel.setFont(FontManager.getRunescapeSmallFont());
+            add(subLabel, c);
+
+            addMouseListener(mouseListener);
+        }
+    }
+
+    private class ListEntryMouseListener extends MouseAdapter {
+        private final Color normalBgColour = ColorScheme.DARKER_GRAY_COLOR;
+        private final Color hoverBgColour = ColorScheme.DARKER_GRAY_HOVER_COLOR;
+
+        @Override
+        public void mouseEntered(MouseEvent e) {
+            e.getComponent().setBackground(hoverBgColour);
+        }
+
+        @Override
+        public void mouseExited(MouseEvent e) {
+            e.getComponent().setBackground(normalBgColour);
+        }
+
+        @Override
+        public void mouseClicked(MouseEvent e) {
+            if (SwingUtilities.isLeftMouseButton(e)) {
+                BanksListEntry entryClicked = ((EntryPanel) e.getComponent()).entry;
+                interactionListener.selectedToOpen(entryClicked);
+
+                if (!e.getComponent().contains(MouseInfo.getPointerInfo().getLocation())) {
+                    mouseExited(e);
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/com/bankmemory/SeedVaultsListPanel.java
+++ b/src/main/java/com/bankmemory/SeedVaultsListPanel.java
@@ -1,4 +1,4 @@
-package main.java.com.bankmemory;
+package com.bankmemory;
 
 import com.bankmemory.data.BankWorldType;
 import com.bankmemory.util.Constants;

--- a/src/main/java/com/bankmemory/bankview/BankViewPanel.java
+++ b/src/main/java/com/bankmemory/bankview/BankViewPanel.java
@@ -91,6 +91,14 @@ public class BankViewPanel extends JPanel {
     }
 
     /**
+     * Customize the title and message shown when there is no data to display.
+     * Call this before {@link #displayNoDataMessage()}.
+     */
+    public void setNoDataMessage(String title, String message) {
+        errorPanel.setContent(title, message);
+    }
+
+    /**
      * Resets filter, resets list data, resets scroll position and removes UI components.
      * Indirectly: releases some held objects (by resetting the list).
      */

--- a/src/main/java/com/bankmemory/data/AbstractDataStoreUpdateListener.java
+++ b/src/main/java/com/bankmemory/data/AbstractDataStoreUpdateListener.java
@@ -20,4 +20,19 @@ public abstract class AbstractDataStoreUpdateListener implements DataStoreUpdate
     public void displayNameMapUpdated() {
         // NO OP
     }
+
+    @Override
+    public void currentSeedVaultsListChanged() {
+        // NO OP
+    }
+
+    @Override
+    public void currentSeedVaultsListOrderChanged() {
+        // NO OP
+    }
+
+    @Override
+    public void snapshotSeedVaultsListChanged() {
+        // NO OP
+    }
 }

--- a/src/main/java/com/bankmemory/data/ConfigReaderWriter.java
+++ b/src/main/java/com/bankmemory/data/ConfigReaderWriter.java
@@ -24,6 +24,8 @@ class ConfigReaderWriter {
     private static final String PLUGIN_BASE_GROUP = "bankMemory";
     private static final String CURRENT_LIST_KEY = "currentList";
     private static final String SNAPSHOT_LIST_KEY = "snapshotList";
+    private static final String CURRENT_SEED_VAULT_LIST_KEY = "currentSeedVaultList";
+    private static final String SNAPSHOT_SEED_VAULT_LIST_KEY = "snapshotSeedVaultList";
     private static final String NAME_MAP_KEY = "nameMap";
 
     private final Gson gson;
@@ -65,6 +67,28 @@ class ConfigReaderWriter {
 
     void writeBankSnapshots(List<BankSave> banks) {
         ConfigWrite configWrite = new ConfigWrite(PLUGIN_BASE_GROUP, SNAPSHOT_LIST_KEY, new ArrayList<>(banks));
+        scheduleConfigWrite(configWrite);
+    }
+
+    List<BankSave> readCurrentSeedVaults() {
+        Type deserialiseType = new TypeToken<List<BankSave>>() {}.getType();
+        List<BankSave> fromDataStore = loadDataFromConfig(CURRENT_SEED_VAULT_LIST_KEY, deserialiseType, new ArrayList<>(), "Current seed vault list");
+        return upgradeBankSaves(fromDataStore);
+    }
+
+    void writeCurrentSeedVaults(List<BankSave> vaults) {
+        ConfigWrite configWrite = new ConfigWrite(PLUGIN_BASE_GROUP, CURRENT_SEED_VAULT_LIST_KEY, new ArrayList<>(vaults));
+        scheduleConfigWrite(configWrite);
+    }
+
+    List<BankSave> readSeedVaultSnapshots() {
+        Type deserialiseType = new TypeToken<List<BankSave>>() {}.getType();
+        List<BankSave> fromDataStore = loadDataFromConfig(SNAPSHOT_SEED_VAULT_LIST_KEY, deserialiseType, new ArrayList<>(), "Snapshot seed vault list");
+        return upgradeBankSaves(fromDataStore);
+    }
+
+    void writeSeedVaultSnapshots(List<BankSave> vaults) {
+        ConfigWrite configWrite = new ConfigWrite(PLUGIN_BASE_GROUP, SNAPSHOT_SEED_VAULT_LIST_KEY, new ArrayList<>(vaults));
         scheduleConfigWrite(configWrite);
     }
 

--- a/src/main/java/com/bankmemory/data/DataStoreUpdateListener.java
+++ b/src/main/java/com/bankmemory/data/DataStoreUpdateListener.java
@@ -8,4 +8,11 @@ public interface DataStoreUpdateListener {
     void snapshotBanksListChanged();
 
     void displayNameMapUpdated();
+
+    // Seed vault specific notifications
+    default void currentSeedVaultsListChanged() {}
+
+    default void currentSeedVaultsListOrderChanged() {}
+
+    default void snapshotSeedVaultsListChanged() {}
 }

--- a/src/main/java/com/bankmemory/data/StorageType.java
+++ b/src/main/java/com/bankmemory/data/StorageType.java
@@ -1,4 +1,4 @@
-package main.java.com.bankmemory.data;
+package com.bankmemory.data;
 
 public enum StorageType {
     BANK,

--- a/src/main/java/com/bankmemory/data/StorageType.java
+++ b/src/main/java/com/bankmemory/data/StorageType.java
@@ -1,0 +1,18 @@
+package main.java.com.bankmemory.data;
+
+public enum StorageType {
+    BANK,
+    SEED_VAULT;
+
+    @Override
+    public String toString() {
+        switch (this) {
+            case BANK:
+                return "Bank";
+            case SEED_VAULT:
+                return "Seed Vault";
+            default:
+                return name();
+        }
+    }
+}

--- a/src/test/java/com/bankmemory/BankMemoryPluginTest.java
+++ b/src/test/java/com/bankmemory/BankMemoryPluginTest.java
@@ -32,6 +32,7 @@ import org.mockito.runners.MockitoJUnitRunner;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -91,9 +92,11 @@ public class BankMemoryPluginTest {
 
         SwingUtilities.invokeAndWait(noCatch(bankMemoryPlugin::startUp));
 
-        verify(clientThread).invokeLater(ac.capture());
+        verify(clientThread, atLeastOnce()).invokeLater(ac.capture());
         verify(currentBankPanelController, never()).startUp(any());
-        ac.getValue().run();
+        for (Runnable r : ac.getAllValues()) {
+            r.run();
+        }
         verify(currentBankPanelController).startUp(pluginPanel.getCurrentBankViewPanel());
     }
 

--- a/src/test/java/com/bankmemory/BankMemoryPluginTest.java
+++ b/src/test/java/com/bankmemory/BankMemoryPluginTest.java
@@ -1,6 +1,15 @@
 package com.bankmemory;
 
 import com.bankmemory.data.PluginDataStore;
+import com.bankmemory.BankDiffPanel;
+import com.bankmemory.BankMemoryItemOverlay;
+import com.bankmemory.BankSavesTopPanel;
+import com.bankmemory.SeedVaultSavesTopPanel;
+import com.bankmemory.CurrentSeedVaultPanelController;
+import com.bankmemory.SavedSeedVaultPanelController;
+import com.bankmemory.SeedVaultDiffPanelController;
+import com.bankmemory.bankview.BankViewPanel;
+import com.bankmemory.bankview.BankViewPanel;
 import com.google.inject.Guice;
 import com.google.inject.Inject;
 import com.google.inject.Injector;
@@ -35,11 +44,21 @@ public class BankMemoryPluginTest {
     @Mock @Bind private PluginDataStore pluginDataStore;
     @Mock @Bind private BankMemoryConfig bankMemoryConfig;
     @Mock @Bind private OverlayManager overlayManager;
+    @Mock @Bind private BankMemoryItemOverlay itemOverlay;
     @Mock private CurrentBankPanelController currentBankPanelController;
+    @Mock private CurrentSeedVaultPanelController currentSeedVaultPanelController;
     @Mock private SavedBanksPanelController savedBanksPanelController;
+    @Mock private SavedSeedVaultPanelController savedSeedVaultPanelController;
     @Mock private BankDiffPanelController bankDiffPanelController;
+    @Mock private SeedVaultDiffPanelController seedVaultDiffPanelController;
     @Mock private BankMemoryPluginPanel pluginPanel;
     @Mock private Injector pluginInjector;
+    @Mock private BankSavesTopPanel bankSavesTopPanel;
+    @Mock private SeedVaultSavesTopPanel seedVaultSavesTopPanel;
+    @Mock private BankDiffPanel banksDiffPanel;
+    @Mock private BankDiffPanel seedVaultDiffPanel;
+    @Mock private BankViewPanel currentSeedVaultViewPanel;
+    @Mock private BankViewPanel currentBankViewPanel;
 
     @Inject private TestBankMemoryPlugin bankMemoryPlugin;
 
@@ -49,9 +68,21 @@ public class BankMemoryPluginTest {
         bankMemoryPlugin.setInjector(pluginInjector);
         when(pluginInjector.getInstance(BankMemoryPluginPanel.class)).thenReturn(pluginPanel);
         when(pluginInjector.getInstance(CurrentBankPanelController.class)).thenReturn(currentBankPanelController);
+        when(pluginInjector.getInstance(CurrentSeedVaultPanelController.class)).thenReturn(currentSeedVaultPanelController);
         when(pluginInjector.getInstance(SavedBanksPanelController.class)).thenReturn(savedBanksPanelController);
+        when(pluginInjector.getInstance(SavedSeedVaultPanelController.class)).thenReturn(savedSeedVaultPanelController);
         when(pluginInjector.getInstance(BankDiffPanelController.class)).thenReturn(bankDiffPanelController);
-        when(pluginPanel.getSavedBanksTopPanel()).thenReturn(mock(BankSavesTopPanel.class));
+        when(pluginInjector.getInstance(SeedVaultDiffPanelController.class)).thenReturn(seedVaultDiffPanelController);
+
+        // Panels returned from pluginPanel
+        when(pluginPanel.getSavedBanksTopPanel()).thenReturn(bankSavesTopPanel);
+        when(pluginPanel.getSavedSeedVaultTopPanel()).thenReturn(seedVaultSavesTopPanel);
+        when(pluginPanel.getCurrentSeedVaultViewPanel()).thenReturn(currentSeedVaultViewPanel);
+        when(pluginPanel.getCurrentBankViewPanel()).thenReturn(currentBankViewPanel);
+
+        // Diff panels from top panels
+        when(bankSavesTopPanel.getDiffPanel()).thenReturn(banksDiffPanel);
+        when(seedVaultSavesTopPanel.getDiffPanel()).thenReturn(seedVaultDiffPanel);
     }
 
     @Test


### PR DESCRIPTION
**What**
- Adds Seed Vault as an additional source alongside the Bank.
- Listens to ItemContainerID.SEED_VAULT.
- Snapshots, Compare, Search, Export all work per source.

**Behavior**
- No changes to existing Bank behavior.
- UI adds a simple dropdown (Bank | Seed Vault).
- Seed Vault requires opening the Seed Vault UI (same as Bank needing the bank open).

**Storage/Migration**
- Snapshots are stored separately per source to avoid mixing.
- Existing bank snapshots are preserved (non-breaking).

**Notes**
- Pricing (GE/HA) unchanged.
- Bank-only filler filters are skipped for Seed Vault.